### PR TITLE
Created alternative component and container folders, /xcomponents and…

### DIFF
--- a/client/redux/destinationReducer.js
+++ b/client/redux/destinationReducer.js
@@ -1,0 +1,27 @@
+
+import * as types from "./actionTypes.js";
+
+const initialState = {
+  source_active: true,
+  source_uri: '',
+  data: {},
+  contentType: 'JSON',
+  hasAuth: false,
+  authType: "",
+}
+
+const DestinationReducer = (state=initialState, action) => {
+
+  switch(action.type) {
+    case types.ACTIVATE_PANEL:
+      const destination_active;
+      if (action.payload === "mockups") { destination_active = true; }
+      else { destination_active = false; }
+      return {
+        ...state,
+        destination_active,
+      };
+  }
+}
+
+export default DestinationReducer;

--- a/client/redux/mockupsReducer.js
+++ b/client/redux/mockupsReducer.js
@@ -1,0 +1,27 @@
+
+import * as types from "./actionTypes.js";
+
+const initialState = {
+  source_active: true,
+  source_uri: '',
+  data: {},
+  contentType: 'JSON',
+  hasAuth: false,
+  authType: "",
+}
+
+const MockupsReducer = (state=initialState, action) => {
+
+  switch(action.type) {
+    case types.ACTIVATE_PANEL:
+      const mockups_active;
+      if (action.payload === "mockups") { mockups_active = true; }
+      else { mockups_active = false; }
+      return {
+        ...state,
+        mockups_active,
+      };
+  }
+}
+
+export default MockupsReducer;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dom": "^16.8.6",
     "react-feather": "^1.1.6",
     "react-json-view": "^1.19.1",
+    "react-redux": "^7.1.1",
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0",
     "styled-components": "^4.3.1",

--- a/src/main/containers/App.jsx
+++ b/src/main/containers/App.jsx
@@ -1,14 +1,20 @@
 import { hot } from 'react-hot-loader/root';
 import styled from 'styled-components';
 import React from 'react';
-import Panels from './Panels.jsx';
-import { TestsProvider } from '../testsContext';
+// import Panels from './Panels.jsx';
+// import { TestsProvider } from '../testsContext';
+import XPanels from '../xcontainers/XPanels';
 
+// const App = () => (
+//   <div>
+//     <TestsProvider>
+//       <Panels />
+//     </TestsProvider>
+//   </div>
+// );
 const App = () => (
   <div>
-    <TestsProvider>
-      <Panels />
-    </TestsProvider>
+    <XPanels />
   </div>
 );
 export default hot(App);

--- a/src/main/xcontainers/StyledPanel.jsx
+++ b/src/main/xcontainers/StyledPanel.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const StyledPanel = styled.section`
+  border-right: 1px solid #BCC1C2;
+  max-height: 100vh;
+  overflow-y: scroll;
+  padding: ${(props) => {
+    if (props.active) return '3em 4em';
+    return '3em auto';
+  }};
+  position: relative;
+  width: ${props => (props.active ? '80vw' : '10vw')};
+  h1 {
+    color: #949C9E;
+    font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-size: 0.825em;
+    font-weight: 400;
+    text-align: center;
+    text-transform: uppercase;
+  }
+  h3 {
+    text-align: left;
+  }
+  &>div {
+    background-color: #FFFFFF;
+    border-bottom: 1px solid #F0F3F4;
+    margin-bottom: 2em;
+    margin-top: 1em;
+    padding-bottom: 2em;
+    position: sticky;
+    top: 0px;
+    z-index: 1;
+  }
+`;
+
+export default StyledPanel;

--- a/src/main/xcontainers/XDestinationPanel.js
+++ b/src/main/xcontainers/XDestinationPanel.js
@@ -1,0 +1,25 @@
+import React from 'react';
+// import RequestBar from '../components/RequestBar.jsx';
+import PropTypes from 'prop-types';
+import StyledPanel from './StyledPanel.jsx';
+// import PerformanceMetrics from '../components/PerformanceMetrics.jsx';
+
+const DestinationPanel = ({ onClick, active }) => (
+
+
+    <StyledPanel
+      onClick={onClick}
+      active={active}
+      style={{ cursor: 'pointer' }}
+    >
+      <h1>Destination</h1>
+    </StyledPanel>
+
+);
+
+DestinationPanel.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  active: PropTypes.bool.isRequired,
+}
+
+export default DestinationPanel;

--- a/src/main/xcontainers/XMockupsPanel.js
+++ b/src/main/xcontainers/XMockupsPanel.js
@@ -1,0 +1,25 @@
+import React from 'react';
+// import RequestBar from '../components/RequestBar.jsx';
+import PropTypes from 'prop-types';
+import StyledPanel from './StyledPanel.jsx';
+// import PerformanceMetrics from '../components/PerformanceMetrics.jsx';
+
+const MockupsPanel = ({ onClick, active }) => (
+
+
+    <StyledPanel
+      onClick={onClick}
+      active={active}
+      style={{ cursor: 'pointer' }}
+    >
+      <h1>Mockups</h1>
+    </StyledPanel>
+
+);
+
+MockupsPanel.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  active: PropTypes.bool.isRequired,
+}
+
+export default MockupsPanel;

--- a/src/main/xcontainers/XPanels.js
+++ b/src/main/xcontainers/XPanels.js
@@ -1,0 +1,64 @@
+import { connect } from 'react-redux';
+import React from 'react';
+import styled from 'styled-components';
+import io from 'socket.io-client';
+import XSourcePanel from './XSourcePanel';
+import XMockupsPanel from './XMockupsPanel';
+import XDestinationPanel from './XDestinationPanel';
+
+const socket = io.connect('http://localhost:3001/');
+
+
+const XPanels = () => {
+  // const [activePanel, setActivePanel] = useState('source');
+  // const [data, setData] = useState(undefined);
+  // const [getFetchTimes, setGetFetchTimes] = useState([]);
+  // const [postFetchTimes, setPostFetchTimes] = useState([]);
+  // const [hContentType, setContentType] = useState('');
+
+  // const [tests, setTests] = useContext(TestsContext);
+
+  const XPanelsWrapper = styled.section`
+    display: flex;
+    height: 100vh;
+  `;
+
+  socket.on('post_received', (postedData) => {
+    // setData(postedData);
+    // setTests([{
+    //   payload: postedData, status: '', name: 'Test #1',
+    // }]);
+
+    // clear old performance metrics on new post
+    // if (getFetchTimes.length) setGetFetchTimes([]);
+    // if (postFetchTimes.length) setPostFetchTimes([]);
+    console.log(postedData);
+  });
+
+  return (
+    <XPanelsWrapper>
+      <XSourcePanel
+      />
+
+      <XMockupsPanel
+      />
+
+      <XDestinationPanel
+      />
+    </XPanelsWrapper>
+  );
+};
+
+const mapStateToProps = () => {
+  return {
+    placeholder: null,
+  };
+};
+
+const mapDispatchToProps = () => {
+  return {
+    placeholder: null,
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(XPanels);

--- a/src/main/xcontainers/XSourcePanel.js
+++ b/src/main/xcontainers/XSourcePanel.js
@@ -1,0 +1,25 @@
+import React from 'react';
+// import RequestBar from '../components/RequestBar.jsx';
+import PropTypes from 'prop-types';
+import StyledPanel from './StyledPanel.jsx';
+// import PerformanceMetrics from '../components/PerformanceMetrics.jsx';
+
+const SourcePanel = ({ onClick, active }) => (
+
+
+    <StyledPanel
+      onClick={onClick}
+      active={active}
+      style={{ cursor: 'pointer' }}
+    >
+      <h1>Source</h1>
+    </StyledPanel>
+
+);
+
+SourcePanel.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  active: PropTypes.bool.isRequired,
+}
+
+export default SourcePanel;


### PR DESCRIPTION
Addresses issue #21 

Created alternative component and container folders, /xcomponents and /xcontainers to house rebuilt redux implementation.
    Added react-redux
    extended active panel reducer to apply to destination and mockups reducers as well
    began to implement mapstatetoprops and mapdispatchtoprops in panel container

@wmagee03 can you take a stab at finishing the mapstatetoprops and mapdispatchtoprops implementation in the panel container?

