### PR TITLE
Visualizer Implemented, edit bodyItem implemented

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -20,7 +20,7 @@ function createWindow() {
   expressApp.use(bodyParser.urlencoded({ extended: true }));
   expressApp.use(bodyParser.json());
 
-  server.listen(3001);
+  server.listen(3002);
 
   mainWindow = new BrowserWindow({
     width: 1200,

--- a/src/main/xcomponents/BodyItem.js
+++ b/src/main/xcomponents/BodyItem.js
@@ -1,12 +1,50 @@
-import React from 'react';
+import React, { Component } from 'react';
+import ReactJson from 'react-json-view';
 // import PropTypes from 'prop-types';
 
-// change this into a class component if you'd like.
-const BodyItem = ({ bodyItemId, bodyItem }) => (
-  <div>
-    Look at me! I'm a BodyItem. When I have a visualizer I'll be displaying:
-    {JSON.stringify(bodyItem)}
-  </div>
-);
+class BodyItem extends Component{
+  render () {
+    const editable = this.props.modifyBodyItem;
+    const styles = {
+      borderRadius: '5px',
+      fontFamily: '\'IBM Plex Mono\', monospace',
+      fontSize: '90%',
+      maxHeight: '250px',
+      overflow: 'auto',
+      margin: '0.75em auto',
+      padding: '1em',
+      border: '1px solid grey'
+    };
+    
+    const changeObject = (src) => {
+
+      const customResponse = JSON.stringify(src.updated_src);
+      // modifyBodyItem expects an entire bodyItem
+      const modifiedBodyItem = {
+        ...this.props.bodyItem,
+        customResponse
+      }
+      this.props.modifyBodyItem(modifiedBodyItem);
+    };
+
+    const src = JSON.parse(this.props.bodyItem.customResponse);
+    
+    return (
+      <div>
+        <ReactJson
+            src={src}
+            theme='shapeshifter:inverted'
+            iconStyle='circle'
+            style={styles}
+            collapsed={2}
+            onAdd={(editable) ? changeObject : false}
+            onEdit={(editable) ? changeObject : changeObject}
+            onDelete={(editable) ? changeObject : false}
+            enableClipboard={false}
+            />
+    </div>
+    )  
+  }
+};
 
 export default BodyItem;

--- a/src/main/xcomponents/BodyItems.js
+++ b/src/main/xcomponents/BodyItems.js
@@ -17,6 +17,7 @@ class BodyItems extends Component {
           key={`BodyItem-${key}`}
           bodyItemId={key}
           bodyItem={bodies[key]}
+          modifyBodyItem={this.props.modifyBodyItem}
         />
       )
     }

--- a/src/main/xcomponents/RequestBar.jsx
+++ b/src/main/xcomponents/RequestBar.jsx
@@ -10,7 +10,6 @@ const RequestBar = ({createBodyFromSource}) => {
 
     const handleChange = (e) => {
         url = e.target.value;
-        console.log('url from handleChange', url);
     }
 
     const parseXmlToJson = (xml) => {
@@ -24,7 +23,6 @@ const RequestBar = ({createBodyFromSource}) => {
 
     const fetchData = (e) => {
         e.preventDefault();
-        console.log("URL from fetch", url);
         fetch(url)
         .then(res => {
             const val = res.headers.get('content-type');
@@ -32,12 +30,10 @@ const RequestBar = ({createBodyFromSource}) => {
                 XMLorJSON = 'XML';
                 return res.text().then(xml => parseXmlToJson(xml));
             }
-            console.log('val', val)
             XMLorJSON = 'JSON';
             return res.json();
         })
         .then(data => {
-            console.log(data);
             const stringifiedData = JSON.stringify(data);
             const newBodyItem = {
                 sourceRoute: url,
@@ -59,7 +55,9 @@ const RequestBar = ({createBodyFromSource}) => {
             <Select>
                 <option value='GET'> GET </option>
             </Select>
-            <Input onChange={handleChange}/>
+            <Input 
+            onChange={handleChange} 
+            />
             <Button type='submit' value='Submit' variation="positive"> Send </Button>
         </Form>
     )

--- a/src/main/xcomponents/bodyItemVisualizer.js
+++ b/src/main/xcomponents/bodyItemVisualizer.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import DataTree from '../components/DataTree.jsx';
+
+const bodyItemVisualizer = (props) => {
+    return (
+        <DataTree />
+    )
+}
+
+export default bodyItemVisualizer;

--- a/src/main/xcontainers/BodyItemsContainer.js
+++ b/src/main/xcontainers/BodyItemsContainer.js
@@ -3,16 +3,18 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bodyItemsCollectionSelector } from '../../../thingsToImplement/redux/combinedReducers';
 import BodyItems from '../xcomponents/BodyItems';
+import * as actions from '../../../thingsToImplement/redux/actions';
 
 
 class BodyItemsContainer extends Component {
 
   render() {
-
+    // TODO: Remove this prop drill of modifyBodyItem reducer, and implement in edit modal instead, once that is made
     return (
       <div>
         <BodyItems
           bodyItems = {this.props.bodyItems}
+          modifyBodyItem = {this.props.modifyBodyItem}
         />
       </div>
     );
@@ -23,5 +25,10 @@ class BodyItemsContainer extends Component {
 const mapStateToProps = (state, ownProps) => ({
     bodyItems: bodyItemsCollectionSelector(state, ownProps.collection),
 });
+const mapDispatchToProps = dispatch => {
+  return {
+    modifyBodyItem: bodyItem => dispatch(actions.modifyBodyItem(bodyItem)),
+  };
+}
 
-export default connect(mapStateToProps)(BodyItemsContainer);
+export default connect(mapStateToProps, mapDispatchToProps)(BodyItemsContainer);

--- a/thingsToImplement/redux/actionTypes.js
+++ b/thingsToImplement/redux/actionTypes.js
@@ -4,14 +4,11 @@ export const ACTIVATE_PANEL = "ACTIVATE_PANEL";
 // End of General Action Types
 
 // Action Types for Source Panel
-export const CREATE_BODY_FROM_SOURCE = "CREATE_BODY_FROM_SOURCE";
-
 export const SET_SOURCE_URI = "SET_SOURCE_URI";
 export const SET_CONTENT_TYPE = "SET_CONTENT_TYPE";
 export const SET_AUTHORIZATION = "SET_AUTHORIZATION";
 export const SET_AUTH_TYPE = "SET_AUTH_TYPE";
 export const ADD_TO_STAGE = "ADD_TO_STAGE";
-
 // End of Action Types for Source Panel
 
 // Action Types for Mockups Panel
@@ -26,8 +23,14 @@ export const DELETE_TEST = "DELETE_TEST";
 
 // End of Action Types for Destination Panel
 
-// Action Types for BodyItemContainer
-export const ALL_ITEMS = "ALL_ITEMS";
-export const CLONED_ITEMS = "CLONED_ITEMS";
-export const STAGED_ITEMS = "STAGED_ITEMS";
-export const HOSTED_ITEMS = "HOSTED_ITEMS";
+// Action Types for BodyItems
+    // Reducer Action Types
+    export const CREATE_BODY_FROM_SOURCE = "CREATE_BODY_FROM_SOURCE";
+    export const MODIFY_BODY_ITEM = "MODIFY_BODY_ITEM";
+    // Selector Action Types
+    export const ALL_ITEMS = "ALL_ITEMS";
+    export const CLONED_ITEMS = "CLONED_ITEMS";
+    export const STAGED_ITEMS = "STAGED_ITEMS";
+    export const HOSTED_ITEMS = "HOSTED_ITEMS";
+// End of Action Types for BodyItems
+

--- a/thingsToImplement/redux/actions.js
+++ b/thingsToImplement/redux/actions.js
@@ -14,10 +14,6 @@ export const addToStage = (bodyItem) => ({
     type: types.ADD_TO_STAGE,
     payload: bodyItem,
 });
-export const createBodyFromSource = (data) => ({
-    type: types.CREATE_BODY_FROM_SOURCE,
-    payload: data,
-});
 export const setSourceURI = (uri) => ({
     type: types.SET_SOURCE_URI,
     payload: uri,
@@ -70,6 +66,18 @@ export const deleteTest = (testName) => ({
     payload: testName,
 });
 // End of Mockups Panel Action Creators
+
+// BodyItem Action Creators
+export const createBodyFromSource = (data) => ({
+    type: types.CREATE_BODY_FROM_SOURCE,
+    payload: data,
+});
+
+export const modifyBodyItem = (data) => ({
+    type: types.MODIFY_BODY_ITEM,
+    payload: data,
+});
+// End of BodyItem Action Creators
 
 // BodyItem Selector Action Creators
 export const BodyItemFilters = {

--- a/thingsToImplement/redux/bodyItemsReducer.js
+++ b/thingsToImplement/redux/bodyItemsReducer.js
@@ -72,16 +72,24 @@ const initialState = {
 };
 
 const bodyItemsReducer = (state = initialState, action) => {
+  const {bodyItems} = state;  
   switch (action.type) {
     case types.CREATE_BODY_FROM_SOURCE:
       const newCount = state.itemCount + 1;
-      const {bodyItems} = state;
       bodyItems[newCount] = action.payload;
+      bodyItems[newCount].bodyItemId = newCount;
       return {
         ...state,
         itemCount: newCount,
         bodyItems,
       };
+    case types.MODIFY_BODY_ITEM:
+      const id = action.payload.bodyItemId;
+      bodyItems[id] = action.payload;
+      return {
+        ...state,
+        bodyItems
+      }
     default:
       return state;
   }


### PR DESCRIPTION
    Implements Visualizer in bodyItem component
    
    Adds Reducer modifyBodyItem to rewrite a given item in store
    
    Currently enables editing from source panel, to be disabled later when edit-modal is implemented
    
    Co-authored-by: David Neuhaus <david@neuha.us>

     Co-authored-by: Derek Cross <derekcrosslu@gmail.com>

